### PR TITLE
Change CursorLockMode to Locked instead of Confined

### DIFF
--- a/Assets/Code/CameraControl/ControlModeSwitcher.cs
+++ b/Assets/Code/CameraControl/ControlModeSwitcher.cs
@@ -17,7 +17,7 @@ public class ControlModeSwitcher : MonoBehaviour {
 
 	void Start() {
 		Cursor.visible = false;
-		Cursor.lockState = CursorLockMode.Confined;
+		Cursor.lockState = CursorLockMode.Locked;
 		if (this.ControlModes.Any()) {
 			this.SetMode(this.ControlModes[0]);
 		}


### PR DESCRIPTION
With the CursorLockMode set to confined, at least on Linux, the cursor was able to move to the edges of the window at which point it would no longer be possible to rotate the camera further in that direction. Changing it to locked means that the cursor is locked in the center of the window, which fixes this issue.